### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ oJ    // json
 Smap scans these [1237 ports](https://gist.githubusercontent.com/s0md3v/3e953e8e15afebc1879a2245e74fc90f/raw/1e20288e9bef43b60f7306b6f7e23044dabd9b8c/shodan_ports.txt) by default. If you want to display results for certain ports, use the `-p` option.
 
 ```
-smap -p21-30,80,443 -iL targets.txt
+smap -p 21-30,80,443 -iL targets.txt
 ```
 
 ## Considerations


### PR DESCRIPTION
In line 99, the command for testing against specific ports was incorrect. It originally was '-p21-30,80,443' but that wouldn't work when I was trying to use this. I added a space and that worked: 'p 21-30,80,443'